### PR TITLE
Replace dependency with github.com/creack/pty

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ web     | [67296] - Worker 0 (PID: 67330) booted in 0.9s, phase: 0
 ## Prior art
 
 Procman was
-forked from [Hivemind](https://github.com/DarthSim/hivemind) by Sergey Aleksandrovich,
-which was inspired by [Foreman](https://github.com/ddollar/foreman) by David Dollar.
+forked from [Hivemind](https://github.com/DarthSim/hivemind),
+which was inspired by [Foreman](https://github.com/ddollar/foreman).
 
 Differences between Procman, Hivemind, and Foreman?
 
@@ -70,12 +70,10 @@ Differences between Procman, Hivemind, and Foreman?
 
 Why create Procman?
 
-- I had been using `foreman` and the app was feeling sluggish.
-  I wanted to keep using a process manager and wondered if something
-  purpose-built for my app would feel better.
-- I wanted to learn more about testing with Go.
-  Given the complexities of dealing with Unix pipes, concurrency, mutexes,
-  signal handling, etc., this felt like a worthwhile learning experience.
+- I had been using another process manager and the app was feeling sluggish.
+  I wondered if something purpose-built for my app would feel better.
+- I wanted to learn more about macOS test runners on GitHub Actions,
+  testing with Go, Unix pipes, concurrency, mutexes, signal handling, etc.
 
 ## Author
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/croaky/procman
 
 go 1.21
 
-require github.com/pkg/term v1.2.0-beta.2
-
-require golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
+require github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,2 @@
-github.com/pkg/term v1.2.0-beta.2 h1:L3y/h2jkuBVFdWiJvNfYfKmzcCnILw7mJWm2JQuMppw=
-github.com/pkg/term v1.2.0-beta.2/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
-golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 h1:TyHqChC80pFkXWraUUf6RuB5IqFdQieMLwwCJokV2pc=
-golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
+github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=

--- a/output.go
+++ b/output.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"syscall"
 
-	"github.com/pkg/term/termios"
+	"github.com/creack/pty"
 )
 
 // output manages the output display of processes
@@ -20,22 +19,6 @@ type output struct {
 // ptyPipe is used for managing pseudo-terminal (PTY) devices
 type ptyPipe struct {
 	pty, tty *os.File
-}
-
-// openPipe initializes a pseudo-terminal for the given process.
-func (out *output) openPipe(proc *process) (pipe *ptyPipe) {
-	var err error
-	pipe = out.pipes[proc]
-
-	pipe.pty, pipe.tty, err = termios.Pty()
-	check(err)
-
-	proc.Stdout = pipe.tty
-	proc.Stderr = pipe.tty
-	proc.Stdin = pipe.tty
-	proc.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true}
-
-	return
 }
 
 // connect prepares the output for a new process.
@@ -61,6 +44,20 @@ func (out *output) pipeOutput(proc *process) {
 			return true
 		})
 	}(proc, pipe)
+}
+
+// openPipe initializes a pseudo-terminal and starts the given process.
+func (out *output) openPipe(proc *process) (pipe *ptyPipe) {
+	var err error
+	pipe = out.pipes[proc]
+
+	pipe.pty, err = pty.Start(proc.Cmd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening PTY: %v\n", err)
+		os.Exit(1)
+	}
+
+	return
 }
 
 // closePipe closes the pseudo-terminal associated with the process.

--- a/process.go
+++ b/process.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -22,10 +23,15 @@ func (proc *process) running() bool {
 
 // run starts the execution of the process and handles its output.
 func (proc *process) run() {
+	if proc.Process != nil {
+		fmt.Fprintf(os.Stderr, "Process %s already started\n", proc.name)
+		return
+	}
+
 	proc.output.pipeOutput(proc)
 	defer proc.output.closePipe(proc)
 
-	if err := proc.Cmd.Run(); err != nil {
+	if err := proc.Cmd.Wait(); err != nil {
 		proc.output.writeErr(proc, err)
 	}
 }


### PR DESCRIPTION
Replace dependency `github.com/pkg/term` and
subdependency `golang.org/x/sys v0.0.0-20211124211545-fe61309f8881`.

The subdependency had a security issue.
The dependency hadn't been changed in 3y.

`github.com/creack/pty` appears to be the currently best-supported
PTY interface for Go.