### PR TITLE
test: build binary automatically via TestMain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,5 @@ jobs:
         with:
           go-version: "1.25"
 
-      - name: build
-        run: go build -v -o procman .
-
       - name: test
         run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 procman
+Procfile.dev

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ for a PTY interface.
 ## Developing
 
 ```bash
-go build ./...                        # build
 go test ./...                         # run tests
 go vet ./...                          # static checks
 goimports -local "$(go list -m)" -w . # format imports

--- a/procman_test.go
+++ b/procman_test.go
@@ -9,6 +9,18 @@ import (
 	"time"
 )
 
+func TestMain(m *testing.M) {
+	cmd := exec.Command("go", "build", "-o", "procman", ".")
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	os.Remove("procman")
+	os.Remove("Procfile.dev")
+	os.Exit(code)
+}
+
 func TestSetupProcesses(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -134,7 +146,6 @@ func TestWriteErr(t *testing.T) {
 }
 
 // TestProcmanIntegration tests the full procman workflow.
-// Requires `go build -o procman .` to be run first.
 func TestProcmanIntegration(t *testing.T) {
 	content := "echo: echo 'hello'\nsleep: sleep 10"
 	if err := os.WriteFile("Procfile.dev", []byte(content), 0644); err != nil {


### PR DESCRIPTION
Removes the need to run 'go build' before 'go test' by building the
binary in TestMain and cleaning it up after tests complete.

This makes the test suite self-contained and simplifies both the
README instructions and the GitHub Actions workflow.

Also ensures Procfile.dev is cleaned up after integration tests and
added to .gitignore as a fallback.

Co-Authored-By: Warp <agent@warp.dev>
