### PR TITLE
watch: add file watching with automatic process restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ running processes, wait 5s, and then send a `SIGKILL` to all remaining processes
 It runs the processes in `Procfile.dev` "as-is";
 It does not load environment variables from `.env` before running.
 
+## File watching
+
+Add `# watch: PATTERNS` to automatically restart a process when files change:
+
+```txt
+web: bundle exec ruby cmd/web.rb  # watch: lib/**/*.rb,ui/**/*.haml
+esbuild: bun run buildwatch
+```
+
+Patterns are relative to the directory containing `Procfile.dev`.
+Glob patterns support `*` (single directory) and `**` (recursive).
+Processes without a watch annotation run without file watching.
+Changes are debounced (500ms) to avoid rapid restarts.
+
 `procman` is distributed via Go source code,
 not via a Homebrew package.
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,16 @@ Patterns are relative to the directory containing `Procfile.dev`.
 Glob patterns support `*` (single directory) and `**` (recursive).
 Processes without a watch annotation run without file watching.
 Changes are debounced (500ms) to avoid rapid restarts.
+On change, procman sends SIGINT, waits for the process to exit, then restarts it.
 
 `procman` is distributed via Go source code,
 not via a Homebrew package.
 
-`procman` depends on [github.com/creack/pty](https://github.com/creack/pty/tree/master)
-for a PTY interface.
+`procman` depends on:
+
+- [creack/pty](https://github.com/creack/pty) for PTY interface
+- [fsnotify/fsnotify](https://github.com/fsnotify/fsnotify) for file watching
+- [bmatcuk/doublestar](https://github.com/bmatcuk/doublestar) for glob patterns
 
 ## Developing
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
-	github.com/creack/pty v1.1.21
+	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.9.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,10 @@ module github.com/croaky/procman
 
 go 1.25
 
-require github.com/creack/pty v1.1.21
+require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/creack/pty v1.1.21
+	github.com/fsnotify/fsnotify v1.9.0
+)
+
+require golang.org/x/sys v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
-github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
 github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -84,7 +84,6 @@ type output struct {
 	pipes         map[*process]*os.File
 }
 
-
 func main() {
 	procNames, err := parseArgs(os.Args)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -104,6 +104,23 @@ func TestParseProcfile(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name:    "With watch patterns",
+			content: "web: bundle exec ruby cmd/web.rb  # watch: lib/**/*.rb,ui/**/*.haml",
+			want: []procDef{
+				{name: "web", cmd: "bundle exec ruby cmd/web.rb", watchPatterns: []string{"lib/**/*.rb", "ui/**/*.haml"}},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Mixed with and without watch",
+			content: "web: ruby web.rb  # watch: *.rb\nesbuild: bun build",
+			want: []procDef{
+				{name: "web", cmd: "ruby web.rb", watchPatterns: []string{"*.rb"}},
+				{name: "esbuild", cmd: "bun build"},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -243,6 +260,70 @@ func TestWriteErr(t *testing.T) {
 	expected := "\033[1;38;5;31mtestProcess \033[0m| \033[0;31mtest error\033[0m\n"
 	if got := buf.String(); got != expected {
 		t.Errorf("Expected output %q, got %q", expected, got)
+	}
+}
+
+func TestMatchesPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		path     string
+		want     bool
+	}{
+		{
+			name:     "Simple glob match",
+			patterns: []string{"*.rb"},
+			path:     "app.rb",
+			want:     true,
+		},
+		{
+			name:     "Simple glob no match",
+			patterns: []string{"*.rb"},
+			path:     "app.go",
+			want:     false,
+		},
+		{
+			name:     "Recursive glob match",
+			patterns: []string{"lib/**/*.rb"},
+			path:     "lib/models/user.rb",
+			want:     true,
+		},
+		{
+			name:     "Recursive glob no match wrong dir",
+			patterns: []string{"lib/**/*.rb"},
+			path:     "app/models/user.rb",
+			want:     false,
+		},
+		{
+			name:     "Multiple patterns first matches",
+			patterns: []string{"*.rb", "*.haml"},
+			path:     "view.haml",
+			want:     true,
+		},
+		{
+			name:     "Multiple patterns none match",
+			patterns: []string{"*.rb", "*.haml"},
+			path:     "style.css",
+			want:     false,
+		},
+		{
+			name:     "Directory pattern match",
+			patterns: []string{"ui/**/*.haml"},
+			path:     "ui/views/index.haml",
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &watcher{
+				proc:    &process{watchPatterns: tt.patterns, output: &output{}},
+				workDir: "", // empty means path is already relative
+			}
+			if got := w.matchesPattern(tt.path); got != tt.want {
+				t.Errorf("matchesPattern(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Add watching to procman where it benefits projects of all languages
rather than build it into Ruby or Go projects/frameworks.

Syntax: add `# watch: PATTERNS` to Procfile.dev entries:

    web: bundle exec ruby cmd/web.rb  # watch: lib/**/*.rb

On file change matching a pattern, procman sends SIGINT to the process,
waits for exit, and restarts. Changes are debounced (500ms) to avoid
rapid restarts during multi-file saves.

Processes without a watch annotation behave exactly as before.

Co-Authored-By: Warp <agent@warp.dev>